### PR TITLE
Correction liste déroulante des zones pour les vacances scolaires

### DIFF
--- a/admin/templates/admin_config6.twig
+++ b/admin/templates/admin_config6.twig
@@ -417,7 +417,7 @@
 										<td>
 											<select class="form-control" name="holidays_zone">
 												<option>{{ trad.holidays_zone_msg }}</option>
-												{{ d.otionVacances | raw }}
+												{{ d.optionVacances | raw }}
 											</select>
 										</td>
 									</tr>


### PR DESCRIPTION
En raison d'une typo, la liste déroulante des zones pour les vacances scolaires était vide